### PR TITLE
HOTFIX : cron création mailbox gandi

### DIFF
--- a/src/tools/conseillers/onboardingConseiller.ts
+++ b/src/tools/conseillers/onboardingConseiller.ts
@@ -13,7 +13,7 @@ const slugify = require('slugify');
 
 execute(__filename, async ({ app, logger, exit, mailer, delay, Sentry }) => {
   const conseillers = await app.service(service.conseillers).Model.find({
-    $or: [{ emailCN: { $exists: false } }, { emailCNError: true }],
+    $or: [{ 'emailCN.address': { $exists: false } }, { emailCNError: true }],
     statut: 'RECRUTE',
   });
   if (conseillers.length === 0) {


### PR DESCRIPTION
Depuis l'automatisation sur le TdP de l’import coop, y a un CRON qui tourne en décalé pour la création des boites mails et l’envoi du mail d’invit’ coop

La requête qui check : const conseillers = await app.service(service.conseillers).Model.find({ $or: [{ emailCN: { $exists: false } }, { emailCNError: true }], statut: 'RECRUTE', });

Sauf que dans le cas où le conseiller a déjà été en rupture, il y a un flag emailCN.deleteMailboxCNError à false, du coup il n’est pas pris en compte car emailCN exists.